### PR TITLE
gofmtで要format時にKOと結果を出力する

### DIFF
--- a/grademe.sh
+++ b/grademe.sh
@@ -63,7 +63,11 @@ test_exe () {
 check_gofmt () {
 	result=`gofmt -d $1`
 	echo -n "gofmt: "
+	test -z "$result"
 	print_result $?
+	if [ -n "$result" ]; then
+		echo "$result"
+	fi
 }
 
 test_ex00 () {

--- a/grademe.sh
+++ b/grademe.sh
@@ -46,7 +46,7 @@ print_case () {
 # $1: name of test case
 # $2: exXX/file.go
 # $3: (optional) args
-test () {
+test_go () {
 	print_case "${@:2}"
 	go run $2 ${@:3} | cat -e > actual/$1.txt
 	diff expected/$1.txt actual/$1.txt
@@ -69,30 +69,30 @@ check_gofmt () {
 test_ex00 () {
 	print_header ex00
 	check_gofmt ${EX00_FILE}
-	test ex00 ${EX00_FILE}
+	test_go ex00 ${EX00_FILE}
 }
 
 test_ex01 () {
 	print_header ex01
 	check_gofmt ${EX01_FILE}
-	test ex01 ${EX01_FILE}
+	test_go ex01 ${EX01_FILE}
 }
 
 test_ex02 () {
 	print_header ex02
 	check_gofmt ${EX02_FILE}
-	test ex02_no_arg ${EX02_FILE}
-	test ex02_example ${EX02_FILE} marvin@student.42tokyo.jp abc@def.123
-	test ex02_257 ${EX02_FILE} veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery_long_email_address@example.com
+	test_go ex02_no_arg ${EX02_FILE}
+	test_go ex02_example ${EX02_FILE} marvin@student.42tokyo.jp abc@def.123
+	test_go ex02_257 ${EX02_FILE} veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery_long_email_address@example.com
 }
 
 test_ex03 () {
 	print_header ex03
 	check_gofmt ${EX03_FILE}
-	test ex03_1 ${EX03_FILE} 1
-	test ex03_4 ${EX03_FILE} 4
-	test ex03_10 ${EX03_FILE} 10
-	test ex03_12 ${EX03_FILE} 12
+	test_go ex03_1 ${EX03_FILE} 1
+	test_go ex03_4 ${EX03_FILE} 4
+	test_go ex03_10 ${EX03_FILE} 10
+	test_go ex03_12 ${EX03_FILE} 12
 }
 
 test_ex04 () {


### PR DESCRIPTION
Fix #1

## 変更内容
gofmtで要formatな時に、OKと表示されるのを修正しました。
KOとdiffを表示するようにしました。

## 出力例
```
$ ./grademe.sh ex00

[ex00]
gofmt: KO
diff -u ../go-piscine-go-00/ex00/hello-world.go.orig ../go-piscine-go-00/ex00/hello-world.go
--- ../go-piscine-go-00/ex00/hello-world.go.orig        2021-05-03 21:07:38.000000000 +0900
+++ ../go-piscine-go-00/ex00/hello-world.go     2021-05-03 21:07:38.000000000 +0900
@@ -3,5 +3,5 @@
 import "fmt"
 
 func main() {
-               fmt.Println("Hello World!")
+       fmt.Println("Hello World!")
 }
../go-piscine-go-00/ex00/hello-world.go
OK
```